### PR TITLE
Use literal package name in text

### DIFF
--- a/src/components/main.js
+++ b/src/components/main.js
@@ -84,8 +84,8 @@ const Main = ({ name, dependency }) => {
         variant="muted"
         style={{ maxWidth: 600 }}
       >
-        Learn how to use {name} by viewing and forking example apps that make
-        use of {name} on CodeSandbox.
+        Learn how to use {dependency.dependency} by viewing and forking example apps that make
+        use of {dependency.dependency} on CodeSandbox.
       </Text>
       <MainComponent>
         <div>


### PR DESCRIPTION
Instead of the stylised version in some places